### PR TITLE
run cmds with input on stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,28 @@ cmd.stderr   #=> ''
 cmd.run.stdout #=> 'hi'
 ```
 
-Some helpers:
+### Run with input on stdin
+
+A single input line
+
+```ruby
+input = "echo hi"
+cmd = Scmd.new("sh").run(input)
+cmd.stdout #=> 'hi'
+```
+
+Multiple input lines:
+
+```ruby
+input = ["echo hi", "echo err 1>&2"]
+cmd = Scmd.new("sh").run(input)
+cmd.stdout #=> 'hi'
+cmd.stderr #=> 'err'
+```
+
+### Some helpers
+
+Ask if cmd was successful:
 
 ```ruby
 puts cmd.stderr if !cmd.success?

--- a/lib/scmd/command.rb
+++ b/lib/scmd/command.rb
@@ -32,14 +32,18 @@ module Scmd
       "#<#{self.class}:0x#{self.object_id.to_s(16)} @cmd_str=#{self.cmd_str.inspect} @exitcode=#{@exitcode.inspect}>"
     end
 
-    def run
-      run! rescue Failure
+    def run(input=nil)
+      run!(input) rescue Failure
       self
     end
 
-    def run!
+    def run!(input=nil)
       begin
         status = Open4::popen4(@cmd_str) do |pid, stdin, stdout, stderr|
+          if !input.nil?
+            [*input].each{|line| stdin.puts line.to_s}
+            stdin.close
+          end
           @pid =  pid.to_i
           @stdout += stdout.read.strip
           @stderr += stderr.read.strip

--- a/test/command_tests.rb
+++ b/test/command_tests.rb
@@ -1,57 +1,85 @@
 require "assert"
 require 'scmd/command'
 
-class CommandTests < Assert::Context
-  desc "a command"
-  setup do
-    @success_cmd = Scmd::Command.new("echo hi")
-    @failure_cmd = Scmd::Command.new("cd /path/that/does/not/exist")
-  end
-  subject { @success_cmd }
+module Scmd
 
-  should have_readers :cmd_str, :pid, :exitcode, :stdout, :stderr
-  should have_instance_methods :run, :run!
-
-  should "know and return its cmd string" do
-    assert_equal "echo hi", subject.cmd_str
-    assert_equal "echo hi", subject.to_s
-  end
-
-  should "default its result values" do
-    assert_nil subject.pid
-    assert_nil subject.exitcode
-    assert_equal '', subject.stdout
-    assert_equal '', subject.stderr
-  end
-
-  should "run the command and set appropriate result data" do
-    @success_cmd.run
-
-    assert_not_nil @success_cmd.pid
-    assert_equal 0, @success_cmd.exitcode
-    assert @success_cmd.success?
-    assert_equal 'hi', @success_cmd.stdout
-    assert_equal '', @success_cmd.stderr
-
-    @failure_cmd.run
-
-    assert_not_nil @failure_cmd.pid
-    assert_not_equal 0, @failure_cmd.exitcode
-    assert_not @failure_cmd.success?
-    assert_equal '', @failure_cmd.stdout
-    assert_not_equal '', @failure_cmd.stderr
-  end
-
-  should "raise an exception on `run!` and a non-zero exitcode" do
-    assert_raises Scmd::Command::Failure do
-      @failure_cmd.run!
+  class CommandTests < Assert::Context
+    desc "a command"
+    setup do
+      @success_cmd = Command.new("echo hi")
+      @failure_cmd = Command.new("cd /path/that/does/not/exist")
     end
+    subject { @success_cmd }
+
+    should have_readers :cmd_str, :pid, :exitcode, :stdout, :stderr
+    should have_instance_methods :run, :run!
+
+    should "know and return its cmd string" do
+      assert_equal "echo hi", subject.cmd_str
+      assert_equal "echo hi", subject.to_s
+    end
+
+    should "default its result values" do
+      assert_nil subject.pid
+      assert_nil subject.exitcode
+      assert_equal '', subject.stdout
+      assert_equal '', subject.stderr
+    end
+
+    should "run the command and set appropriate result data" do
+      @success_cmd.run
+
+      assert_not_nil @success_cmd.pid
+      assert_equal 0, @success_cmd.exitcode
+      assert @success_cmd.success?
+      assert_equal 'hi', @success_cmd.stdout
+      assert_equal '', @success_cmd.stderr
+
+      @failure_cmd.run
+
+      assert_not_nil @failure_cmd.pid
+      assert_not_equal 0, @failure_cmd.exitcode
+      assert_not @failure_cmd.success?
+      assert_equal '', @failure_cmd.stdout
+      assert_not_equal '', @failure_cmd.stderr
+    end
+
+    should "raise an exception on `run!` and a non-zero exitcode" do
+      assert_raises Scmd::Command::Failure do
+        @failure_cmd.run!
+      end
+    end
+
+    should "return itself on `run`, `run!`" do
+      assert_equal @success_cmd, @success_cmd.run
+      assert_equal @success_cmd, @success_cmd.run!
+      assert_equal @failure_cmd, @failure_cmd.run
+    end
+
   end
 
-  should "return itself on `run`, `run!`" do
-    assert_equal @success_cmd, @success_cmd.run
-    assert_equal @success_cmd, @success_cmd.run!
-    assert_equal @failure_cmd, @failure_cmd.run
+  class InputTests < CommandTests
+    desc "that takes input on stdin"
+    setup do
+      @cmd = Command.new("sh")
+    end
+    subject { @cmd }
+
+    should "run the command given a single line of input" do
+      subject.run "echo hi"
+
+      assert @cmd.success?
+      assert_equal 'hi', @cmd.stdout
+    end
+
+    should "run the command given multiple lines of input" do
+      subject.run ["echo hi", "echo err 1>&2"]
+
+      assert @cmd.success?
+      assert_equal 'hi', @cmd.stdout
+      assert_equal 'err', @cmd.stderr
+    end
+
   end
 
 end


### PR DESCRIPTION
This change allows you to pass lines of input on stdin to the cmd
being run.  Pass the lines as arguments to the `run` commands.

Here's an example of this in practice:

``` ruby
input = ["echo hi", "echo err 1>&2"]
cmd = Scmd.new("sh").run(input)
cmd.stdout #=> 'hi'
cmd.stderr #=> 'err'
```
