### PR TITLE
Support jruby

### DIFF
--- a/lib/scmd/command.rb
+++ b/lib/scmd/command.rb
@@ -11,12 +11,17 @@
 #   result data that is stored in instance variables.
 # * See the README.md for a walkthrough of the API.
 
-require 'open4'
-
 module Scmd
   class Command
 
     class Failure < RuntimeError; end
+
+    ENGINE = if !(PLATFORM =~ /java/)
+      require 'open4'
+      Open4
+    else
+      IO
+    end
 
     attr_reader :cmd_str
     attr_reader :pid, :exitcode, :stdout, :stderr
@@ -39,7 +44,7 @@ module Scmd
 
     def run!(input=nil)
       begin
-        status = Open4::popen4(@cmd_str) do |pid, stdin, stdout, stderr|
+        ENGINE::popen4(@cmd_str) do |pid, stdin, stdout, stderr|
           if !input.nil?
             [*input].each{|line| stdin.puts line.to_s}
             stdin.close
@@ -48,7 +53,10 @@ module Scmd
           @stdout += stdout.read.strip
           @stderr += stderr.read.strip
         end
-        @exitcode = status.to_i
+        # `$?` is a thread-safe predefined variable that returns the exit status
+        # of the last child process to terminate:
+        # http://phrogz.net/ProgrammingRuby/language.html#predefinedvariables
+        @exitcode = $?.to_i
       rescue Errno::ENOENT => err
         @exitcode = -1
         @stderr   = err.message


### PR DESCRIPTION
The `open4` gem isn't compatible with jruby because jruby doesn't allow forking.
To allow Scmd to be used with jruby, we can use `IO.popen4`, which provides the
same functionality as the `open4` gem. This commit modifies the command class to
switch `Open4` usage with `IO` when the platform is java.
