### PR TITLE
using 'posix-spawn' instead of 'open4'

### DIFF
--- a/scmd.gemspec
+++ b/scmd.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency("assert")
-  gem.add_dependency("open4")
+  gem.add_dependency("posix-spawn")
 end


### PR DESCRIPTION
This provides fast, constant spawn times across a variety of platforms.
Also, it works natively in jruby (TODO: test it!), so no ENGINE constant
hacking needed.

Addresses #2.
Addresses #5.
