### PR TITLE
reworked pid status gathering using `waitpid2`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,10 @@
 *.gem
 *.log
 *.rbc
+.rbx/
 .bundle
 .config
 .yardoc
-.rvmrc
-.rbenv-version
 Gemfile.lock
 InstalledFiles
 _yardoc


### PR DESCRIPTION
Also removed Errno::ENOENT handling as it is not needed anymore
with moving to posix_spawn.  Finally, moved status gathering to
after the wait pid call.
