### PR TITLE
have `RunError` *optionally* take a custom backtrace

### DIFF
--- a/lib/scmd.rb
+++ b/lib/scmd.rb
@@ -7,4 +7,13 @@ module Scmd
     Command.new(*args, &block)
   end
 
+  TimeoutError = Class.new(::RuntimeError)
+
+  class RunError < ::RuntimeError
+    def initialize(stderr, called_from = nil)
+      super(stderr)
+      set_backtrace(called_from || caller)
+    end
+  end
+
 end

--- a/lib/scmd/command.rb
+++ b/lib/scmd/command.rb
@@ -1,4 +1,5 @@
 require 'posix-spawn'
+require 'scmd'
 
 # Scmd::Command is a base wrapper for handling system commands. Initialize it
 # with with a string specifying the command to execute.  You can then run the
@@ -6,15 +7,6 @@ require 'posix-spawn'
 # create a more custom command wrapper.
 
 module Scmd
-
-  class RunError < ::RuntimeError
-    def initialize(stderr, called_from)
-      super(stderr)
-      set_backtrace(called_from)
-    end
-  end
-
-  TimeoutError = Class.new(::RuntimeError)
 
   class Command
     WAIT_INTERVAL = 0.1 # seconds

--- a/test/unit/scmd_tests.rb
+++ b/test/unit/scmd_tests.rb
@@ -17,4 +17,41 @@ module Scmd
 
   end
 
+  class TimeoutErrorTests < UnitTests
+    desc "TimeoutError"
+    setup do
+      @error = Scmd::TimeoutError.new('test')
+    end
+    subject{ @error }
+
+    should "be a RuntimeError" do
+      assert_kind_of ::RuntimeError, subject
+    end
+
+  end
+
+  class RunErrorTests < UnitTests
+    desc "RunError"
+    setup do
+      @error = Scmd::RunError.new('test')
+    end
+    subject{ @error }
+
+    should "be a RuntimeError" do
+      assert_kind_of ::RuntimeError, subject
+    end
+
+    should "set its backtrace to the caller by default" do
+      assert_match /scmd_tests.rb:.*$/, subject.backtrace.first
+    end
+
+    should "allow passing a custom backtrace" do
+      called_from = caller
+      error = Scmd::RunError.new('test', called_from)
+
+      assert_equal called_from, error.backtrace
+    end
+
+  end
+
 end


### PR DESCRIPTION
This updates the RunError custom exception to be optionally created
with a custom backtrace.  If none is provided, it falls back to the
`caller`.  This makes it behave like any other exception class.

Closes #15.
