### PR TITLE
use a "self-pipe" to handle cmd timeouts

### DIFF
--- a/bench/results.txt
+++ b/bench/results.txt
@@ -6,7 +6,7 @@ mem @ start             38 MB                   ??
 mem @ finish            38 MB                   [31m+   0 MB,   0%[0m
 
          user     system   total    real
-time     0.0 ms   0.0 ms   0.0 ms   62.42 ms
+time     0.0 ms   0.0 ms   0.0 ms   1.864 ms
 
 echo hi: 10 times
 -----------------
@@ -16,7 +16,7 @@ mem @ start             38 MB                   ??
 mem @ finish            38 MB                   [32m-   0 MB,   0%[0m
 
           user      system    total     real
-time      10.0 ms   10.0 ms   40.0 ms   619.93 ms
+time      0.0 ms    10.0 ms   20.0 ms   17.165 ms
 
 echo hi: 100 times
 ------------------
@@ -25,56 +25,56 @@ whysoslow? ..
 mem @ start             38 MB                   ??
 mem @ finish            38 MB                   [32m-   0 MB,   0%[0m
 
-            user        system      total       real
-time        50.0 ms     50.0 ms     330.0 ms    6176.346 ms
+           user       system     total      real
+time       20.0 ms    20.0 ms    130.0 ms   150.305 ms
 
 echo hi: 1000 times
 -------------------
 whysoslow? ..
 
 mem @ start             38 MB                   ??
-mem @ finish            42 MB                   [31m+   4 MB,  10%[0m
+mem @ finish            41 MB                   [31m+   3 MB,   7%[0m
 
-             user         system       total        real
-time         500.0 ms     540.0 ms     3280.0 ms    61703.161 ms
+            user        system      total       real
+time        180.0 ms    190.0 ms    1360.0 ms   1415.856 ms
 
 cat test/support/bigger-than-64k.txt: 1 times
 ---------------------------------------------
 whysoslow? ..
 
-mem @ start             42 MB                   ??
-mem @ finish            42 MB                   [32m-   0 MB,   0%[0m
+mem @ start             41 MB                   ??
+mem @ finish            41 MB                   [32m-   0 MB,   0%[0m
 
-          user      system    total     real
-time      0.0 ms    0.0 ms    0.0 ms    62.127 ms
+         user     system   total    real
+time     0.0 ms   0.0 ms   0.0 ms   3.312 ms
 
 cat test/support/bigger-than-64k.txt: 10 times
 ----------------------------------------------
 whysoslow? ..
 
-mem @ start             42 MB                   ??
-mem @ finish            44 MB                   [31m+   2 MB,   6%[0m
+mem @ start             41 MB                   ??
+mem @ finish            43 MB                   [31m+   2 MB,   4%[0m
 
-           user       system     total      real
-time       10.0 ms    10.0 ms    50.0 ms    620.075 ms
+         user     system   total    real
+time     10.0 ms  10.0 ms  40.0 ms  29.29 ms
 
 cat test/support/bigger-than-64k.txt: 100 times
 -----------------------------------------------
 whysoslow? ..
 
-mem @ start             44 MB                   ??
-mem @ finish            93 MB                   [31m+  49 MB, 110%[0m
+mem @ start             43 MB                   ??
+mem @ finish            85 MB                   [31m+  42 MB,  98%[0m
 
-            user        system      total       real
-time        80.0 ms     100.0 ms    520.0 ms    6185.163 ms
+           user       system     total      real
+time       40.0 ms    40.0 ms    270.0 ms   278.486 ms
 
 cat test/support/bigger-than-64k.txt: 1000 times
 ------------------------------------------------
 whysoslow? ..
 
-mem @ start             93 MB                   ??
-mem @ finish            585 MB                  [31m+ 492 MB, 527%[0m
+mem @ start             85 MB                   ??
+mem @ finish            506 MB                  [31m+ 421 MB, 497%[0m
 
-             user         system       total        real
-time         770.0 ms     900.0 ms     5290.0 ms    61803.114 ms
+            user        system      total       real
+time        370.0 ms    420.0 ms    2650.0 ms   2710.427 ms
 


### PR DESCRIPTION
This switches to defining a stop "self-pipe" for signaling when the
child process has exited.  Intead of looping in the `wait_for_exit`
and checking if you've timed out every `WAIT_INTERVAL`, you instead
just select on the stop pipe with a timeout (or not).  The thread
streaming the child process output also checks if the child process
has exited.  If it has the stream thread writes to the stop pipe
which triggers the wait to end.

Closes #14.

@jcredding ready for review.
