### PR TITLE
update to support Rubinius

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gemspec
 gem 'rake'
 gem 'pry'
 gem "whysoslow"
+
+platform :rbx do
+  gem 'rubysl'
+end


### PR DESCRIPTION
This adds the `rubysl` gem to the rbx platform.  It is needed to run
the test suite on Rubinius.

@jcredding ready for review.
