### PR TITLE
Allow passing an env var hash to commands

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake'
-gem 'pry'
-gem "whysoslow"
+gem 'pry', "~> 0.9.0"
+gem 'whysoslow'
 
 platform :rbx do
   gem 'rubysl'

--- a/test/unit/command_tests.rb
+++ b/test/unit/command_tests.rb
@@ -11,7 +11,8 @@ class Scmd::Command
     end
     subject { @success_cmd }
 
-    should have_readers :cmd_str, :pid, :exitstatus, :stdout, :stderr
+    should have_readers :cmd_str, :env
+    should have_readers :pid, :exitstatus, :stdout, :stderr
     should have_imeths :run, :run!
     should have_imeths :start, :wait, :stop, :kill
     should have_imeths :running?, :success?
@@ -19,6 +20,18 @@ class Scmd::Command
     should "know and return its cmd string" do
       assert_equal "echo hi", subject.cmd_str
       assert_equal "echo hi", subject.to_s
+    end
+
+    should "default its env to an empty hash" do
+      assert_equal({}, subject.env)
+    end
+
+    should "stringify its env hash" do
+      cmd = Scmd::Command.new("echo $SCMD_TEST_VAR", {
+        :SCMD_TEST_VAR => 1
+      })
+      expected = { 'SCMD_TEST_VAR' => '1' }
+      assert_equal expected, cmd.env
     end
 
     should "default its result values" do
@@ -186,6 +199,21 @@ class Scmd::Command
       @big_cmd.start
       assert_nothing_raised{ @big_cmd.wait(1) }
       assert_equal @big_data, @big_cmd.stdout
+    end
+
+  end
+
+  class WithEnvVarTests < UnitTests
+    desc "with environment variables"
+    setup do
+      @cmd = Scmd::Command.new("echo $SCMD_TEST_VAR", {
+        'SCMD_TEST_VAR' => 'test'
+      })
+    end
+
+    should "use them when running the command" do
+      @cmd.run
+      assert_equal "test\n", @cmd.stdout
     end
 
   end


### PR DESCRIPTION
This updates the `Command` class to take a hash for passing env
variables. These are passed to the `popen4` call and are set as
environment variables for the child process. This allows passing
sensitive env vars like passwords without putting them in the
command string.

@kellyredding - This came about with trying to add SQL schema dumping to ardb. I wanted to use scmd to run the commands but I need to set environment variables using the database configuration. One of these is the password and I didn't want to put that in the command string directly. I checked with [posix-spawn and they allowed passing an environment variable hash](https://github.com/rtomayko/posix-spawn/blob/master/lib/posix/spawn.rb#L46) so I wanted to allow using that with scmd. I chose to put the env var hash as the last argument instead of how they have it as an optional first argument.
