### PR TITLE
send specific signals to `kill`

### DIFF
--- a/lib/scmd/command.rb
+++ b/lib/scmd/command.rb
@@ -86,10 +86,10 @@ module Scmd
       end
     end
 
-    def kill
+    def kill(sig = nil)
       return if !running?
 
-      send_kill
+      send_kill(sig)
       wait # indefinitely until cmd is killed
     end
 
@@ -146,8 +146,8 @@ module Scmd
       send_signal 'TERM'
     end
 
-    def send_kill
-      send_signal 'KILL'
+    def send_kill(sig = nil)
+      send_signal(sig || 'KILL')
     end
 
     def send_signal(sig)

--- a/test/system/command_tests.rb
+++ b/test/system/command_tests.rb
@@ -122,6 +122,13 @@ class Scmd::Command
       assert_not @long_cmd.running?
     end
 
+    should "be killable with a non-default signal" do
+      @long_cmd.start
+      @long_cmd.kill('INT')
+
+      assert_not @long_cmd.running?
+    end
+
   end
 
   class BufferDeadlockTests < SystemTests


### PR DESCRIPTION
This updates the `kill` method to task an optional signal name.  By
default it sends the `'KILL'` signal.  This allows you to send a
non-default signal to the command's pid and any child pids.

@jcredding ready for review.
