### PR TITLE
Update posix-spawn dependency

### DIFF
--- a/scmd.gemspec
+++ b/scmd.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.3"])
-  gem.add_dependency("posix-spawn", ["= 0.3.8"])
+  gem.add_development_dependency("assert", ["~> 2.15"])
+  gem.add_dependency("posix-spawn", ["~> 0.3.11"])
 end


### PR DESCRIPTION
This updates the posix-spawn dependency to the latest version and
also switches back to allowing any patch level version updates.

This was originally locked down in c3206e6 because the latest
version of posix-spawn was not compatible with ruby 1.8.7. They
fixed the 1.8.7 errors in v0.3.10.

As an aside, this also fixes an issue with ruby 2.2 we were
experiencing in other gems. In Qs, its benchmark script relies on
creating a unix pipe, spinning up a child process that runs jobs
and passing the writer file descriptor to that child process. In
ruby 1.9 they added `Process.spawn` and by default it closes all
file descriptors to avoid "leaking" file descriptors which can
apparently keep files from being closed properly. posix-spawn tries
to be compatible with ruby so it does the same thing. So in ruby
2.2, qs benchmark script won't work unless it redirects file
descriptors. There was a bug with redirecting the file descriptors
with posix-spawn in v0.3.8 though. By updating the posix-spawn
version, the Qs benchmark script can work as expected in ruby 2.2.

@kellyredding - Ready for review. Other references that I mentioned in this:

* You can see that they added `Process.spawn` in ruby 1.9.1 here: http://svn.ruby-lang.org/repos/ruby/tags/v1_9_1_0/NEWS. It doesn't exist in ruby 1.8.7.
* I can't find anything official about why all the file descriptors are closed by default. Best thing I have seen is something about leaking file descriptors which keeps them from being closed correctly.
* You can google and see a few blogs mentioning the file descriptors being closed issue. The bundler one might be something we have to look into for Sanford and its hot restarting:
 * https://developer.zendesk.com/blog/ruby-2-0-changes-exec-bundler
 * http://blog.infertux.com/2013/03/04/file-descriptor-inheritance-with-ruby/
* I think this change fixed the posix-spawn issue with redirecting file descriptors: https://github.com/rtomayko/posix-spawn/compare/v0.3.8...v0.3.11#diff-e11640637bde29eab3872c4d725529b1R149. I'm not entirely sure what I'm looking at but I'm pretty sure that C code is related to redirecting file descriptors.