### PR TITLE
Allow passing options to posix-spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,33 @@ Raise an exception if not successful with `run!`:
 Scmd.new("cd /path/that/does/not/exist").run! #=> Scmd::Command::Failure
 ```
 
+### Environment variables
+
+Pass environment variables:
+
+```ruby
+cmd = Scmd.new("echo $TEST_VAR", {
+  :env => {
+    'TEST_VAR' => 'hi'
+  }
+})
+```
+
+### Process spawn options
+
+Pass options:
+
+```ruby
+reader, writer = IO.pipe
+# this is an example that uses file descriptor redirection options
+cmd = Scmd.new("echo test 1>&#{writer.fileno}", {
+  :options => { writer => writer }
+})
+reader.gets # => "test\n"
+```
+
+For all the possible options see [posix-spawn](https://github.com/rtomayko/posix-spawn#status).
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/scmd/command.rb
+++ b/lib/scmd/command.rb
@@ -14,12 +14,14 @@ module Scmd
     READ_CHECK_TIMEOUT   = 0.001 # seconds
     DEFAULT_STOP_TIMEOUT = 3     # seconds
 
-    attr_reader :cmd_str, :env
+    attr_reader :cmd_str, :env, :options
     attr_reader :pid, :exitstatus, :stdout, :stderr
 
-    def initialize(cmd_str, env = nil)
+    def initialize(cmd_str, opts = nil)
+      opts ||= {}
       @cmd_str = cmd_str
-      @env     = stringify_hash(env || {})
+      @env     = stringify_hash(opts[:env] || {})
+      @options = opts[:options] || {}
       reset_attrs
     end
 
@@ -131,7 +133,7 @@ module Scmd
       reset_attrs
       @stop_r, @stop_w = IO.pipe
       @read_output_thread = nil
-      @child_process = ChildProcess.new(@cmd_str, @env)
+      @child_process = ChildProcess.new(@cmd_str, @env, @options)
     end
 
     def teardown_run
@@ -165,8 +167,12 @@ module Scmd
 
       attr_reader :pid, :stdin, :stdout, :stderr
 
-      def initialize(cmd_str, env)
-        @pid, @stdin, @stdout, @stderr = *::POSIX::Spawn::popen4(env, cmd_str)
+      def initialize(cmd_str, env, options)
+        @pid, @stdin, @stdout, @stderr = *::POSIX::Spawn::popen4(
+          env,
+          cmd_str,
+          options
+        )
         @wait_pid, @wait_status = nil, nil
       end
 

--- a/test/system/command_tests.rb
+++ b/test/system/command_tests.rb
@@ -159,13 +159,34 @@ class Scmd::Command
     desc "with environment variables"
     setup do
       @cmd = Scmd::Command.new("echo $SCMD_TEST_VAR", {
-        'SCMD_TEST_VAR' => 'test'
+        :env => { 'SCMD_TEST_VAR' => 'test' }
       })
     end
 
     should "use them when running the command" do
       @cmd.run
+      assert @cmd.success?
       assert_equal "test\n", @cmd.stdout
+    end
+
+  end
+
+  class WithOptionsTests < SystemTests
+    desc "with options"
+    setup do
+      @path = "/"
+      # `chdir` is the only one that reliably worked
+      @cmd = Scmd::Command.new("pwd", {
+        :options => { :chdir => @path }
+      })
+    end
+
+    should "use them when running the command" do
+      @cmd.run
+      assert @cmd.success?
+      # if the option didn't work or was ignored it would use this process' dir
+      assert_not_equal "#{Dir.pwd}\n", @cmd.stdout
+      assert_equal "#{@path}\n", @cmd.stdout
     end
 
   end

--- a/test/unit/command_tests.rb
+++ b/test/unit/command_tests.rb
@@ -10,7 +10,7 @@ class Scmd::Command
     end
     subject { @cmd }
 
-    should have_readers :cmd_str, :env
+    should have_readers :cmd_str, :env, :options
     should have_readers :pid, :exitstatus, :stdout, :stderr
     should have_imeths :run, :run!
     should have_imeths :start, :wait, :stop, :kill
@@ -27,10 +27,14 @@ class Scmd::Command
 
     should "stringify its env hash" do
       cmd = Scmd::Command.new("echo $SCMD_TEST_VAR", {
-        :SCMD_TEST_VAR => 1
+        :env => { :SCMD_TEST_VAR => 1 }
       })
       expected = { 'SCMD_TEST_VAR' => '1' }
       assert_equal expected, cmd.env
+    end
+
+    should "default its options to an empty hash" do
+      assert_equal({}, subject.options)
     end
 
     should "default its result values" do


### PR DESCRIPTION
This allows passing options to posix-spawn which allows extra
behavior for the child process that is spawned.

This changes the command interface to take a command string and
opts hash instead of an env hash. The env hash can now be specified
using the `:env` key in the opts hash. This allows passing an
`:options` key in the opts hash for specifying the posix spawn
options.

This is needed for ruby 1.9+. It closes file descriptors when a
child process is spawned. This specifically caused Qs benchmark
script to not work anymore because it used an IO pipe to
communicate between the parent and child process. With this change
the Qs benchmark script can specify the file descriptors it wants
to redirect and the script works as it previously did.

This also updates the README documentation for using the new
options. This includes a section showing how environment variables
can be used which should have been added when environment variable
support was added.

@kellyredding - Ready for review.