### PR TITLE
add a command spy for testing use

### DIFF
--- a/lib/scmd/command.rb
+++ b/lib/scmd/command.rb
@@ -88,10 +88,10 @@ module Scmd
       end
     end
 
-    def kill(sig = nil)
+    def kill(signal = nil)
       return if !running?
 
-      send_kill(sig)
+      send_kill(signal)
       wait # indefinitely until cmd is killed
     end
 
@@ -148,8 +148,8 @@ module Scmd
       send_signal 'TERM'
     end
 
-    def send_kill(sig = nil)
-      send_signal(sig || 'KILL')
+    def send_kill(signal = nil)
+      send_signal(signal || 'KILL')
     end
 
     def send_signal(sig)

--- a/lib/scmd/command_spy.rb
+++ b/lib/scmd/command_spy.rb
@@ -1,0 +1,98 @@
+require 'scmd'
+
+module Scmd
+
+  class CommandSpy
+
+    attr_reader :cmd_str, :env, :options
+    attr_reader :run_calls, :run_bang_calls, :start_calls
+    attr_reader :wait_calls, :stop_calls, :kill_calls
+    attr_accessor :pid, :exitstatus, :stdout, :stderr
+
+    def initialize(cmd_str, opts = nil)
+      opts ||= {}
+      @cmd_str = cmd_str
+      @env     = opts[:env]
+      @options = opts[:options]
+
+      @run_calls,  @run_bang_calls, @start_calls = [], [], []
+      @wait_calls, @stop_calls,     @kill_calls  = [], [], []
+
+      @running = false
+
+      @stdout, @stderr, @pid, @exitstatus = '', '', nil, nil
+    end
+
+    def run(input = nil)
+      @run_calls.push(InputCall.new(input))
+      self
+    end
+
+    def run_called?
+      !@run_calls.empty?
+    end
+
+    def run!(input = nil)
+      @run_bang_calls.push(InputCall.new(input))
+      self
+    end
+
+    def run_bang_called?
+      !@run_bang_calls.empty?
+    end
+
+    def start(input = nil)
+      @start_calls.push(InputCall.new(input))
+      @running = true
+    end
+
+    def start_called?
+      !@start_calls.empty?
+    end
+
+    def wait(timeout = nil)
+      @wait_calls.push(TimeoutCall.new(timeout))
+      @running = false
+    end
+
+    def wait_called?
+      !@wait_calls.empty?
+    end
+
+    def stop(timeout = nil)
+      @stop_calls.push(TimeoutCall.new(timeout))
+      @running = false
+    end
+
+    def stop_called?
+      !@stop_calls.empty?
+    end
+
+    def kill(signal = nil)
+      @kill_calls.push(SignalCall.new(signal))
+      @running = false
+    end
+
+    def kill_called?
+      !@kill_calls.empty?
+    end
+
+    def running?
+      !!@running
+    end
+
+    def success?
+      @exitstatus == 0
+    end
+
+    def to_s
+      @cmd_str.to_s
+    end
+
+    InputCall   = Struct.new(:input)
+    TimeoutCall = Struct.new(:timeout)
+    SignalCall  = Struct.new(:signal)
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,3 +7,5 @@ $LOAD_PATH.unshift(ROOT_PATH)
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
+
+require 'test/support/factory'

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,0 +1,6 @@
+require 'assert/factory'
+
+module Factory
+  extend Assert::Factory
+
+end

--- a/test/unit/command_spy_tests.rb
+++ b/test/unit/command_spy_tests.rb
@@ -1,0 +1,174 @@
+require "assert"
+require 'scmd/command_spy'
+
+class Scmd::CommandSpy
+
+  class UnitTests < Assert::Context
+    desc "Scmd::CommandSpy"
+    setup do
+      @spy_class = Scmd::CommandSpy
+    end
+
+  end
+
+  class InitTests < UnitTests
+    setup do
+      @cmd_str = Factory.string
+      @spy = @spy_class.new(@cmd_str)
+    end
+    subject{ @spy }
+
+    should have_readers :cmd_str, :env, :options
+    should have_readers :run_calls, :run_bang_calls, :start_calls
+    should have_readers :wait_calls, :stop_calls, :kill_calls
+    should have_accessors :pid, :exitstatus, :stdout, :stderr
+    should have_imeths :run, :run_called?, :run!, :run_bang_called?
+    should have_imeths :start, :start_called?
+    should have_imeths :wait, :wait_called?, :stop, :stop_called?
+    should have_imeths :kill, :kill_called?
+    should have_imeths :running?, :success?
+
+    should "know and return its cmd string" do
+      assert_equal @cmd_str, subject.cmd_str
+      assert_equal @cmd_str, subject.to_s
+    end
+
+    should "default its attrs" do
+      assert_nil subject.env
+      assert_nil subject.options
+
+      assert_equal [], subject.run_calls
+      assert_equal [], subject.run_bang_calls
+      assert_equal [], subject.start_calls
+      assert_equal [], subject.wait_calls
+      assert_equal [], subject.stop_calls
+      assert_equal [], subject.kill_calls
+
+      assert_nil subject.pid
+      assert_nil subject.exitstatus
+
+      assert_equal '', subject.stdout
+      assert_equal '', subject.stderr
+    end
+
+    should "allow specifying env and options" do
+      opts = { Factory.string => Factory.string }
+      cmd = Scmd::Command.new(Factory.string, {
+        :env     => { :SCMD_TEST_VAR => 1 },
+        :options => opts
+      })
+      exp = { 'SCMD_TEST_VAR' => '1' }
+      assert_equal exp,  cmd.env
+      assert_equal opts, cmd.options
+    end
+
+    should "know whether it is running or not" do
+      assert_false subject.running?
+
+      subject.run
+      assert_false subject.running?
+      subject.run!
+      assert_false subject.running?
+
+      subject.start
+      assert_true subject.running?
+      subject.stop
+      assert_false subject.running?
+
+      subject.start
+      subject.wait
+      assert_false subject.running?
+
+      subject.start
+      subject.kill
+      assert_false subject.running?
+    end
+
+    should "know if it was successful" do
+      assert_false subject.success?
+
+      subject.exitstatus = 0
+      assert_true subject.success?
+
+      subject.exitstatus = 1
+      assert_false subject.success?
+
+      subject.exitstatus = Factory.string
+      assert_false subject.success?
+    end
+
+    should "track its run calls" do
+      input = Factory.string
+      subject.run(input)
+
+      assert_equal 1, subject.run_calls.size
+      assert_kind_of InputCall, subject.run_calls.first
+      assert_equal input, subject.run_calls.first.input
+
+      subject.run(Factory.string)
+      assert_equal 2, subject.run_calls.size
+    end
+
+    should "track its run! calls" do
+      input = Factory.string
+      subject.run!(input)
+
+      assert_equal 1, subject.run_bang_calls.size
+      assert_kind_of InputCall, subject.run_bang_calls.first
+      assert_equal input, subject.run_bang_calls.first.input
+
+      subject.run!(Factory.string)
+      assert_equal 2, subject.run_bang_calls.size
+    end
+
+    should "track its start calls" do
+      input = Factory.string
+      subject.start(input)
+
+      assert_equal 1, subject.start_calls.size
+      assert_kind_of InputCall, subject.start_calls.first
+      assert_equal input, subject.start_calls.first.input
+
+      subject.start(Factory.string)
+      assert_equal 2, subject.start_calls.size
+    end
+
+    should "track its wait calls" do
+      timeout = Factory.string
+      subject.wait(timeout)
+
+      assert_equal 1, subject.wait_calls.size
+      assert_kind_of TimeoutCall, subject.wait_calls.first
+      assert_equal timeout, subject.wait_calls.first.timeout
+
+      subject.wait(Factory.string)
+      assert_equal 2, subject.wait_calls.size
+    end
+
+    should "track its stop calls" do
+      timeout = Factory.string
+      subject.stop(timeout)
+
+      assert_equal 1, subject.stop_calls.size
+      assert_kind_of TimeoutCall, subject.stop_calls.first
+      assert_equal timeout, subject.stop_calls.first.timeout
+
+      subject.stop(Factory.string)
+      assert_equal 2, subject.stop_calls.size
+    end
+
+    should "track its kill calls" do
+      signal = Factory.string
+      subject.kill(signal)
+
+      assert_equal 1, subject.kill_calls.size
+      assert_kind_of SignalCall, subject.kill_calls.first
+      assert_equal signal, subject.kill_calls.first.signal
+
+      subject.kill(Factory.string)
+      assert_equal 2, subject.kill_calls.size
+    end
+
+  end
+
+end

--- a/test/unit/command_tests.rb
+++ b/test/unit/command_tests.rb
@@ -8,7 +8,7 @@ class Scmd::Command
     setup do
       @cmd = Scmd::Command.new("echo hi")
     end
-    subject { @cmd }
+    subject{ @cmd }
 
     should have_readers :cmd_str, :env, :options
     should have_readers :pid, :exitstatus, :stdout, :stderr
@@ -29,8 +29,8 @@ class Scmd::Command
       cmd = Scmd::Command.new("echo $SCMD_TEST_VAR", {
         :env => { :SCMD_TEST_VAR => 1 }
       })
-      expected = { 'SCMD_TEST_VAR' => '1' }
-      assert_equal expected, cmd.env
+      exp = { 'SCMD_TEST_VAR' => '1' }
+      assert_equal exp, cmd.env
     end
 
     should "default its options to an empty hash" do


### PR DESCRIPTION
This adds a spy object to use in place of actual command objects
in tests.  Stub this in so no commands will actually run and so that
you can test your are calling Scmd's API appropriately.

This also does a few other cleanups:

* some style cleanups
* added a factory class/api for use in the tests

These cleanups were noticed while adding the spy (they probably
should have been done in other efforts as these are our conventions).

@jcredding ready for review.