### PR TITLE
add "test mode" for Scmd

### DIFF
--- a/lib/scmd.rb
+++ b/lib/scmd.rb
@@ -3,8 +3,46 @@ require 'scmd/command'
 
 module Scmd
 
-  def self.new(*args, &block)
-    Command.new(*args, &block)
+  # Scmd can be run in "test mode".  This means that command spies will be used
+  # in place of "live" commands, each time a command is run or started will be
+  # logged in a collection and option-specific spies can be added and used to
+  # "stub" spies with specific attributes in specific contexts.
+
+  def self.new(*args)
+    if !ENV['SCMD_TEST_MODE']
+      Command.new(*args)
+    else
+      self.commands.get(*args)
+    end
+  end
+
+  def self.commands
+    raise NoMethodError if !ENV['SCMD_TEST_MODE']
+    @commands ||= begin
+      require 'scmd/stored_commands'
+      StoredCommands.new
+    end
+  end
+
+  def self.calls
+    raise NoMethodError if !ENV['SCMD_TEST_MODE']
+    @calls ||= []
+  end
+
+  def self.reset
+    raise NoMethodError if !ENV['SCMD_TEST_MODE']
+    self.calls.clear
+    self.commands.remove_all
+  end
+
+  def self.add_command(cmd_str, &block)
+    self.commands.add(cmd_str, &block)
+  end
+
+  class Call < Struct.new(:cmd_str, :input, :cmd)
+    def initialize(cmd_spy, input)
+      super(cmd_spy.cmd_str, input, cmd_spy)
+    end
   end
 
   TimeoutError = Class.new(::RuntimeError)

--- a/lib/scmd/command_spy.rb
+++ b/lib/scmd/command_spy.rb
@@ -20,11 +20,12 @@ module Scmd
 
       @running = false
 
-      @stdout, @stderr, @pid, @exitstatus = '', '', nil, nil
+      @stdout, @stderr, @pid, @exitstatus = '', '', 1, 0
     end
 
     def run(input = nil)
       @run_calls.push(InputCall.new(input))
+      Scmd.calls.push(Scmd::Call.new(self, input))
       self
     end
 
@@ -34,6 +35,7 @@ module Scmd
 
     def run!(input = nil)
       @run_bang_calls.push(InputCall.new(input))
+      Scmd.calls.push(Scmd::Call.new(self, input))
       self
     end
 
@@ -43,6 +45,7 @@ module Scmd
 
     def start(input = nil)
       @start_calls.push(InputCall.new(input))
+      Scmd.calls.push(Scmd::Call.new(self, input))
       @running = true
     end
 
@@ -87,6 +90,26 @@ module Scmd
 
     def to_s
       @cmd_str.to_s
+    end
+
+    def ==(other_spy)
+      if other_spy.kind_of?(CommandSpy)
+        self.cmd_str         == other_spy.cmd_str        &&
+        self.env             == other_spy.env            &&
+        self.options         == other_spy.options        &&
+        self.run_calls       == other_spy.run_calls      &&
+        self.run_bang_calls  == other_spy.run_bang_calls &&
+        self.start_calls     == other_spy.start_calls    &&
+        self.wait_calls      == other_spy.wait_calls     &&
+        self.stop_calls      == other_spy.stop_calls     &&
+        self.kill_calls      == other_spy.kill_calls     &&
+        self.pid             == other_spy.pid            &&
+        self.exitstatus      == other_spy.exitstatus     &&
+        self.stdout          == other_spy.stdout         &&
+        self.stderr          == other_spy.stderr
+      else
+        super
+      end
     end
 
     InputCall   = Struct.new(:input)

--- a/lib/scmd/stored_commands.rb
+++ b/lib/scmd/stored_commands.rb
@@ -1,0 +1,78 @@
+require 'scmd/command_spy'
+
+module Scmd
+
+  class StoredCommands
+
+    attr_reader :hash
+
+    def initialize
+      @hash = Hash.new{ |h, k| h[k] = Stub.new(k) }
+    end
+
+    def add(cmd_str, &block)
+      @hash[cmd_str].tap{ |s| s.set_default_proc(&block) }
+    end
+
+    def get(cmd_str, opts = nil)
+      @hash[cmd_str].call(opts)
+    end
+
+    def remove(cmd_str)
+      @hash.delete(cmd_str)
+    end
+
+    def remove_all
+      @hash.clear
+    end
+
+    def empty?
+      @hash.empty?
+    end
+
+    def ==(other_stored_commands)
+      if other_stored_commands.kind_of?(StoredCommands)
+        self.hash == other_stored_commands.hash
+      else
+        super
+      end
+    end
+
+    class Stub
+
+      attr_reader :cmd_str, :hash
+
+      def initialize(cmd_str)
+        @cmd_str = cmd_str
+        @default_proc = proc{ |cmd_spy| } # no-op
+        @hash = {}
+      end
+
+      def set_default_proc(&block)
+        @default_proc = block if block
+      end
+
+      def with(opts, &block)
+        @hash[opts] = block
+        self
+      end
+
+      def call(opts)
+        block = @hash[opts] || @default_proc
+        CommandSpy.new(@cmd_str, opts).tap(&block)
+      end
+
+      def ==(other_stub)
+        if other_stub.kind_of?(Stub)
+          self.cmd_str == other_stub.cmd_str &&
+          self.hash    == other_stub.hash
+        else
+          super
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/test/unit/scmd_tests.rb
+++ b/test/unit/scmd_tests.rb
@@ -2,6 +2,8 @@ require "assert"
 require 'scmd'
 
 require 'scmd/command'
+require 'scmd/command_spy'
+require 'scmd/stored_commands'
 
 module Scmd
 
@@ -9,10 +11,91 @@ module Scmd
     desc "Scmd"
     subject{ Scmd }
 
-    should have_instance_method :new
+    should have_imeths :new, :commands, :calls, :reset, :add_command
+
+  end
+
+  class NonTestModeTests < UnitTests
+    desc "when NOT in test mode"
 
     should "build a `Command` with the `new` method" do
-      assert_kind_of Scmd::Command, subject.new('echo hi')
+      assert_instance_of Scmd::Command, subject.new('echo hi')
+    end
+
+    should "raise no method error on the test mode API methods" do
+      [:commands, :calls, :reset].each do |meth|
+        assert_raises(NoMethodError) do
+          subject.send(meth)
+        end
+      end
+      assert_raises(NoMethodError) do
+        subject.add_command(Factory.string)
+      end
+    end
+
+  end
+
+  class TestModeTests < UnitTests
+    desc "when in test mode"
+    setup do
+      @orig_scmd_test_mode = ENV['SCMD_TEST_MODE']
+      ENV['SCMD_TEST_MODE'] = '1'
+      Scmd.reset
+    end
+    teardown do
+      Scmd.reset
+      ENV['SCMD_TEST_MODE'] = @orig_scmd_test_mode
+    end
+
+    should "get a command spy from the commands collection with the new` method" do
+      assert_equal Scmd::CommandSpy.new('echo hi'), subject.new('echo hi')
+    end
+
+    should "know its test mode API attrs" do
+      assert_equal StoredCommands.new, subject.commands
+      assert_equal [],                 subject.calls
+    end
+
+    should "clear/remove the test mode API attrs on `reset`" do
+      cmd_str = Factory.string
+      subject.commands.add(cmd_str)
+      subject.calls.push(cmd_str)
+      assert_not_empty subject.commands
+      assert_not_empty subject.calls
+
+      subject.reset
+      assert_empty subject.commands
+      assert_empty subject.calls
+    end
+
+    should "add stored commands using `add_command`" do
+      cmd_str = Factory.string
+      output  = Factory.text
+      assert_not_equal output, subject.new(cmd_str).stdout
+
+      subject.add_command(cmd_str){ |cmd| cmd.stdout = output }
+      assert_equal output, subject.new(cmd_str).stdout
+    end
+
+  end
+
+  class CallTests < UnitTests
+    desc "Call"
+    setup do
+      @cmd_str = Factory.string
+      @input   = Factory.text
+      @cmd     = CommandSpy.new(@cmd_str)
+
+      @call = Call.new(@cmd, @input)
+    end
+    subject{ @call }
+
+    should have_accessors :cmd_str, :input, :cmd
+
+    should "know its attrs" do
+      assert_equal @cmd_str, subject.cmd_str
+      assert_equal @input,   subject.input
+      assert_equal @cmd,     subject.cmd
     end
 
   end

--- a/test/unit/stored_commands_tests.rb
+++ b/test/unit/stored_commands_tests.rb
@@ -1,0 +1,146 @@
+require 'assert'
+require 'scmd/stored_commands'
+
+require 'scmd/command_spy'
+
+class Scmd::StoredCommands
+
+  class UnitTests < Assert::Context
+    desc "Scmd::StoredCommands"
+    setup do
+      @cmd_str = Factory.string
+      @opts    = { Factory.string => Factory.string }
+      @output  = Factory.text
+
+      @commands = Scmd::StoredCommands.new
+    end
+    subject{ @commands }
+
+    should have_imeths :add, :get, :remove, :remove_all, :empty?
+
+    should "allow adding and getting commands when yielded a command" do
+      yielded = nil
+      subject.add(@cmd_str) do |cmd|
+        yielded = cmd
+        cmd.stdout = @output
+      end
+      cmd_spy = subject.get(@cmd_str, {})
+
+      assert_instance_of Scmd::CommandSpy, yielded
+      assert_equal yielded, cmd_spy
+      assert_equal @output, cmd_spy.stdout
+    end
+
+    should "return a stub when adding a command" do
+      stub = subject.add(@cmd_str)
+      assert_instance_of Scmd::StoredCommands::Stub, stub
+
+      stub.with(@opts){ |cmd| cmd.stdout = @output }
+      cmd = subject.get(@cmd_str, @opts)
+      assert_equal @output, cmd.stdout
+
+      cmd = subject.get(@cmd_str, {})
+      assert_not_equal @output, cmd.stdout
+    end
+
+    should "return a unaltered cmd spy for a cmd str that isn't configured" do
+      cmd_spy = Scmd::CommandSpy.new(@cmd_str)
+      cmd = subject.get(@cmd_str)
+
+      assert_equal cmd_spy, cmd
+    end
+
+    should "not call a cmd block until it is retrieved" do
+      called = false
+      subject.add(@cmd_str){ called = true }
+      assert_false called
+      subject.get(@cmd_str)
+      assert_true called
+    end
+
+    should "allow removing a stub" do
+      subject.add(@cmd_str){ |cmd| cmd.stdout = @output }
+      cmd = subject.get(@cmd_str)
+      assert_equal @output, cmd.stdout
+
+      subject.remove(@cmd_str)
+      cmd = subject.get(@cmd_str)
+      assert_not_equal @output, cmd.stdout
+    end
+
+    should "allow removing all commands" do
+      subject.add(@cmd_str){ |cmd| cmd.stdout = @output }
+      other_cmd_str = Factory.string
+      subject.add(other_cmd_str){ |cmd| cmd.stdout = @output }
+
+      subject.remove_all
+      cmd = subject.get(@cmd_str)
+      assert_not_equal @output, cmd.stdout
+      cmd = subject.get(other_cmd_str)
+      assert_not_equal @output, cmd.stdout
+    end
+
+    should "know if it is empty or not" do
+      assert_empty subject
+
+      subject.add(@cmd_str)
+      assert_not_empty subject
+
+      subject.remove_all
+      assert_empty subject
+    end
+
+    should "know if it is equal to another stored commands or not" do
+      cmds1 = Scmd::StoredCommands.new
+      cmds2 = Scmd::StoredCommands.new
+      assert_equal cmds1, cmds2
+
+      cmds1.add(@cmd_str)
+      assert_not_equal cmds1, cmds2
+    end
+
+  end
+
+  class StubTests < UnitTests
+    desc "Stub"
+    setup do
+      @stub = Stub.new(@cmd_str)
+    end
+    subject{ @stub }
+
+    should have_readers :cmd_str, :hash
+    should have_imeths :set_default_proc, :with, :call
+
+    should "default its default command proc" do
+      cmd_spy = Scmd::CommandSpy.new(@cmd_str, @opts)
+      cmd = subject.call(@opts)
+      assert_equal cmd_spy, cmd
+    end
+
+    should "allow setting its default proc" do
+      subject.set_default_proc{ |cmd| cmd.stdout = @output }
+      cmd = subject.call(@opts)
+      assert_equal @output, cmd.stdout
+    end
+
+    should "allow setting commands for specific opts" do
+      cmd = subject.call(@opts)
+      assert_equal '', cmd.stdout
+
+      subject.with({}){ |cmd| cmd.stdout = @output }
+      cmd = subject.call({})
+      assert_equal @output, cmd.stdout
+    end
+
+    should "know if it is equal to another stub or not" do
+      stub1 = Stub.new(@cmd_str)
+      stub2 = Stub.new(@cmd_str)
+      assert_equal stub1, stub2
+
+      Assert.stub(stub1, [:cmd_str, :hash].choice){ Factory.string }
+      assert_not_equal stub1, stub2
+    end
+
+  end
+
+end


### PR DESCRIPTION
Test mode turns on a bunch testing utilities for Scmd.  This means
that command spies will be used in place of "live" commands, each
time a command is run or started will be logged in a collection and
option-specific spies can be added and used to "stub" spies with
specific attributes in specific contexts.

In non-test-mode, everything behaves as before: `.new` returns
"live" commands and the test mode API all raises `NoMethodError`s.
To turn on test mode, set and env var: `ENV['SCMD_TEST_MODE'] = '1'`.

Note: this also updates the command spy to have non-nil default
values for exit status and pid.  The goal here is to default with
realistic values that can be overridden and also so that commands
are successful by default.  The original defaults were a big 
nuisance when used in application testing.

@jcredding ready for review.